### PR TITLE
Build dir is `build` not `dist`

### DIFF
--- a/.github/workflows/gh-pages-workflow.yml
+++ b/.github/workflows/gh-pages-workflow.yml
@@ -35,6 +35,6 @@ jobs:
     - name: Deploy master to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@v4
       with:
-        folder: dist
+        folder: build
         clean: true
         single-commit: true


### PR DESCRIPTION
## Type of Change

- **Something else:** Actions workflow

## What issue does this relate to?

cc #13

### What should this PR do?

Fixes the build path for the workflow, we use `build` here, not the standard `dist`.

### What are the acceptance criteria?

Hopefully works once merged, GH Pages workflow only runs on master.